### PR TITLE
Add pyproject and CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ source venv312/bin/activate
 ```
 
 ### 3. Install Python Dependencies
+Install the project in editable mode so the `brave-search` command is available:
 ```bash
-pip install mcp-use langchain-openai python-dotenv httpx
+pip install -e .
 ```
 
 ### 4. Set Up Environment Variables
@@ -72,17 +73,17 @@ npx --version   # Should show version number
 
 ### Basic Usage
 ```bash
-python brave_search.py "Company Name"
+brave-search "Company Name"
 ```
 
 ### Examples
 ```bash
 # Search for Migros (Swiss retailer)
-python brave_search.py "Migros"
+brave-search "Migros"
 
 # Search for any company
-python brave_search.py "Nestlé"
-python brave_search.py "Credit Suisse"
+brave-search "Nestlé"
+brave-search "Credit Suisse"
 ```
 
 ### Expected Output

--- a/brave_search.py
+++ b/brave_search.py
@@ -227,13 +227,23 @@ oder danach:
     
     print(f"\nResult: {result}")
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Search for company information using Brave/Wikidata and then an agent.')
-    parser.add_argument('company', help='The company name to search for')
+def console_main() -> None:
+    """Entry point for the ``brave-search`` console script."""
+    parser = argparse.ArgumentParser(
+        description="Search for company information using Brave/Wikidata and then an agent."
+    )
+    parser.add_argument("company", help="The company name to search for")
     args = parser.parse_args()
-    
+
     if not os.getenv("OPENAI_API_KEY"):
-        print("Error: OPENAI_API_KEY is not set. Please set it in your .env file or environment.", file=sys.stderr)
+        print(
+            "Error: OPENAI_API_KEY is not set. Please set it in your .env file or environment.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     asyncio.run(main(args.company))
+
+
+if __name__ == "__main__":
+    console_main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "brave-search-agent"
+version = "0.1.0"
+description = "Company information extraction agent using Brave Search API and MCP"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+dependencies = [
+    "mcp-use",
+    "langchain-openai",
+    "python-dotenv",
+    "httpx"
+]
+
+[tool.setuptools]
+py-modules = ["brave_search"]
+
+[project.scripts]
+brave-search = "brave_search:console_main"


### PR DESCRIPTION
## Summary
- package the project with a `pyproject.toml`
- expose a `brave-search` console command
- update README with installation and usage instructions

## Testing
- `pip install -e .` *(fails: Could not fetch build dependencies)*